### PR TITLE
Refactor/seperate ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ECR Push - mcp-server
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactor/seperate-ci"]
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,23 @@
 FROM gradle:8.8-jdk17 AS builder
+
 WORKDIR /workspace
 
-COPY gradlew gradlew.bat settings.gradle ./
+COPY gradlew .
+COPY gradlew.bat .
 COPY gradle ./gradle
-COPY order-platform-msa-mcp-server ./order-platform-msa-mcp-server
-COPY order-platform-msa-mcp-server/build.cloud.gradle ./order-platform-msa-mcp-server/build.gradle
 
-RUN ./gradlew :order-platform-msa-mcp-server:bootJar -x test
+COPY build.cloud.gradle build.gradle
+
+COPY src ./src
+
+RUN ./gradlew bootJar
 
 FROM eclipse-temurin:17-jre-jammy
+
 WORKDIR /app
 
-COPY --from=builder /workspace/order-platform-msa-mcp-server/build/libs/*.jar /app/application.jar
+COPY --from=builder /workspace/build/libs/*.jar /app/application.jar
 
 EXPOSE 8099
+
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/app/application.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY gradlew.bat .
 COPY gradle ./gradle
 
 COPY build.cloud.gradle build.gradle
+COPY settings.gradle .
 
 COPY src ./src
 

--- a/build.cloud.gradle
+++ b/build.cloud.gradle
@@ -1,23 +1,7 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
-}
-
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
-}
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-        maven { url 'https://repo.spring.io/milestone' }
-        maven { url 'https://repo.spring.io/snapshot' }
-        flatDir { dirs 'libs' }
-    }
 }
 
 

--- a/build.cloud.gradle
+++ b/build.cloud.gradle
@@ -1,8 +1,25 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven { url 'https://repo.spring.io/milestone' }
+        maven { url 'https://repo.spring.io/snapshot' }
+        flatDir { dirs 'libs' }
+    }
+}
+
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
@@ -16,7 +33,6 @@ java {
 ext {
     set('springAiVersion', "1.0.1")
 }
-
 
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven { url 'https://repo.spring.io/milestone' }
+        maven { url 'https://repo.spring.io/snapshot' }
+        flatDir { dirs 'libs' }
+    }
+}
+
 rootProject.name = 'mcp-server'


### PR DESCRIPTION
### 각 레포에서 ci가 가능하게 리팩토링을 진행했습니다.

- Dockerfile: 모든 서비스의 Dockerfile에 COPY libs ./libs를 추가하여 빌드 시 로컬 JAR 파일을 포함하도록 수정했습니다.
- settings.gradle: 모든 settings.gradle 파일에 flatDir 저장소를 추가하여 libs 디렉터리에서 의존성을 찾도록 설정했습니다.
- build.cloud.gradle: msa-common-security 의존성이 누락된 모든 서비스에 해당 의존성을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * CI pipeline now triggers on an additional branch.
  * Docker build consolidated to use a single root build; runtime image continues to expose the same port and startup behavior.
  * Gradle settings centralized for plugins and dependency repositories.
* Refactor
  * Simplified Gradle configuration by removing module-specific dependencies from the cloud build file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->